### PR TITLE
enable canvas if not editor

### DIFF
--- a/Assets/Plugins/SubDisplayProjector/Prefab/SubDisplayProjector.prefab
+++ b/Assets/Plugins/SubDisplayProjector/Prefab/SubDisplayProjector.prefab
@@ -89,7 +89,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &156463642711876321
 RectTransform:
   m_ObjectHideFlags: 0
@@ -166,6 +166,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2514199153950663699}
   - component: {fileID: 5577805042868360005}
+  - component: {fileID: 6565924804805263938}
   m_Layer: 0
   m_Name: SubDisplayProjector
   m_TagString: Untagged
@@ -204,3 +205,16 @@ MonoBehaviour:
   adjustMode: 0
   isBasedSafeArea: 1
   subDisplay: {fileID: 4412139510653225844}
+--- !u!114 &6565924804805263938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6502020023736194158}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7dbc95f581e9402c9507dbf3897a9ea2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _targetCanvas: {fileID: 745548984474493621}

--- a/Assets/Plugins/SubDisplayProjector/Scripts/EnableCanvasIfNotEditor.cs
+++ b/Assets/Plugins/SubDisplayProjector/Scripts/EnableCanvasIfNotEditor.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace SubDisplayProjector
+{
+    // `SubDisplayProjector` renders to an external display via a Canvas.
+    // This Canvas is always visible in the Scene view of the Editor, so the Canvas's GameObject is disabled in the prefab.
+    // This script enables the Canvas's GameObject when not in the Editor.
+    public class EnableCanvasIfNotEditor : MonoBehaviour
+    {
+        [SerializeField] private Canvas _targetCanvas = null!;
+
+        private void Awake()
+        {
+            if (!Application.isEditor) _targetCanvas.gameObject.SetActive(true);
+        }
+    }
+}

--- a/Assets/Plugins/SubDisplayProjector/Scripts/EnableCanvasIfNotEditor.cs.meta
+++ b/Assets/Plugins/SubDisplayProjector/Scripts/EnableCanvasIfNotEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7dbc95f581e9402c9507dbf3897a9ea2
+timeCreated: 1761276656

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/SampleScene.unity
+    guid: 9fc0d4010bbf28b4594072e72b8655ab
   m_configObjects: {}


### PR DESCRIPTION
This pull request updates the `SubDisplayProjector` prefab and related scripts to ensure the display canvas is only enabled outside of the Unity Editor, preventing it from cluttering the Scene view during development.
It also adds the sample scene to the build settings.

Please release this as version 1.2.6. I can update the version in this PR if needed.

Thank you.
